### PR TITLE
Update SuqsQuestState.cpp

### DIFF
--- a/Source/SUQS/Private/SuqsQuestState.cpp
+++ b/Source/SUQS/Private/SuqsQuestState.cpp
@@ -473,7 +473,7 @@ void USuqsQuestState::ChangeStatus(ESuqsQuestStatus NewStatus)
 		case ESuqsQuestStatus::Completed: 
 			Progression->RaiseQuestCompleted(this);
 			break;
-		case ESuqsObjectiveStatus::Failed:
+		case (ESuqsQuestStatus)ESuqsObjectiveStatus::Failed:
 			Progression->RaiseQuestFailed(this);
 			break;
 		case ESuqsQuestStatus::Incomplete:

--- a/Source/SUQS/Private/SuqsQuestState.cpp
+++ b/Source/SUQS/Private/SuqsQuestState.cpp
@@ -473,7 +473,7 @@ void USuqsQuestState::ChangeStatus(ESuqsQuestStatus NewStatus)
 		case ESuqsQuestStatus::Completed: 
 			Progression->RaiseQuestCompleted(this);
 			break;
-		case (ESuqsQuestStatus)ESuqsObjectiveStatus::Failed:
+		case ESuqsQuestStatus::Failed:
 			Progression->RaiseQuestFailed(this);
 			break;
 		case ESuqsQuestStatus::Incomplete:


### PR DESCRIPTION
Fixes #2  - Explicit cast to stop editor from throwing an error when using launcher version.