### PR TITLE
Fix Compilation Warning C4996 : PRAGMA_DISABLE_OPTIMIZATION / PRAGMA_ENABLE_OPTIMIZATION has been deprecated.

### DIFF
--- a/Source/SUQSTest/Private/TestQuestEvents.cpp
+++ b/Source/SUQSTest/Private/TestQuestEvents.cpp
@@ -5,7 +5,7 @@
 #include "CallbackCatcher.h"
 #include "SuqsTaskState.h"
 
-PRAGMA_DISABLE_OPTIMIZATION
+UE_DISABLE_OPTIMIZATION_SHIP
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTestQuestTopLevelEvents, "SUQSTest.QuestTopLevelEvents",
                                  EAutomationTestFlags::EditorContext |
@@ -615,4 +615,4 @@ bool FTestQuestDetailEvents::RunTest(const FString& Parameters)
 	return true;
 }
 
-PRAGMA_ENABLE_OPTIMIZATION
+UE_ENABLE_OPTIMIZATION_SHIP


### PR DESCRIPTION
Compiler Warning Original Text:
```
0>TestQuestEvents.cpp(8): Warning C4996 : PRAGMA_DISABLE_OPTIMIZATION has been deprecated. Use UE_DISABLE_OPTIMIZATION for temporary development or UE_DISABLE_OPTIMIZATION_SHIP to submit Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.
0>TestQuestEvents.cpp(618): Warning C4996 : PRAGMA_ENABLE_OPTIMIZATION has been deprecated. Use UE_ENABLE_OPTIMIZATION for temporary development or UE_ENABLE_OPTIMIZATION_SHIP to submit Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.
```